### PR TITLE
Add Railway deploy config (Dockerfile, railway.json, .dockerignore)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Build artifacts
+target/
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Environment and secrets — never ship these into an image
+.env
+.env.*
+*.pem
+*.key
+*.crt
+secrets/
+
+# Editor / OS metadata
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Logs and local-dev scratch
+*.log
+tmp/
+.cache/
+
+# Docs that don't need to be in the image
+README.md
+LICENSE
+docs/
+specs/
+
+# CI / dev tooling that has no runtime role
+.github/
+scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:1.88-slim-bookworm AS builder
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY crates ./crates
+
+RUN cargo build --locked --release -p joyride-oracle
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/joyride-oracle /usr/local/bin/joyride-oracle
+
+ENV RUST_LOG=info
+ENV ORACLE_BIND_ADDR=0.0.0.0:8083
+
+EXPOSE 8083
+
+CMD ["joyride-oracle"]

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "dockerfilePath": "Dockerfile",
+    "watchPatterns": [
+      "/Cargo.toml",
+      "/Cargo.lock",
+      "/src/**",
+      "/crates/**",
+      "/Dockerfile",
+      "/railway.json"
+    ]
+  }
+}


### PR DESCRIPTION
 Adds the build artifacts needed to deploy joyride-oracle to Railway as a service. 