### PR TITLE
harden Pyth ingestion against silent-handshake stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +25,206 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -42,6 +251,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +289,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -105,6 +353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +385,18 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -156,6 +425,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +453,22 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -189,6 +494,33 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -218,6 +550,12 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -298,6 +636,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,7 +656,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -372,6 +723,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +777,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -481,6 +850,34 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "hyper"
@@ -767,6 +1164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +1203,7 @@ dependencies = [
  "anyhow",
  "eventsource-client",
  "futures-util",
+ "httpmock",
  "joyride-oracle-wire",
  "reqwest",
  "serde",
@@ -825,16 +1232,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -862,6 +1324,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "memchr"
@@ -902,6 +1367,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -950,7 +1421,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -970,6 +1441,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1001,6 +1478,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,7 +1519,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1033,10 +1535,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1055,6 +1582,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1118,6 +1651,46 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1275,6 +1848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,7 +1931,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1363,6 +1945,16 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -1414,6 +2006,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,10 +2056,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1485,7 +2112,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1523,6 +2150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +2177,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1549,6 +2187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1596,7 +2243,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1718,7 +2365,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1793,6 +2440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +2482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,6 +2498,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1910,7 +2579,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1934,6 +2603,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,7 +2654,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1965,7 +2665,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2190,7 +2890,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2211,7 +2911,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2231,7 +2931,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2271,7 +2971,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,3 +21,9 @@ serde_json = "1"
 anyhow = "1"
 futures-util = "0.3"
 tracing = "0.1"
+
+[dev-dependencies]
+# Test-only tokio surface: macros for #[tokio::test], rt for the runtime,
+# net + io-util for the hand-rolled SSE server in stall-watchdog tests.
+tokio = { version = "1", features = ["sync", "time", "macros", "rt", "net", "io-util"] }
+httpmock = "0.7"

--- a/crates/core/src/pyth.rs
+++ b/crates/core/src/pyth.rs
@@ -15,8 +15,21 @@ use joyride_oracle_wire::PriceUpdate;
 
 /// Default Hermes API endpoint.
 pub const HERMES_URL: &str = "https://hermes.pyth.network";
+/// Explicit User-Agent so Hermes/Cloudflare logs identify us, and so we
+/// don't rely on whatever default the HTTP client sends (the eventsource
+/// crate sets only Accept + Cache-Control).
+const USER_AGENT: &str = "joyride-oracle/1.0 (+ops@joyride.exchange)";
 const FRESHNESS_LOG_INTERVAL: Duration = Duration::from_secs(5);
+/// Frame-level idle: reconnect if no SSE frame of any kind arrives within
+/// this window. Comments (heartbeats) and malformed events both reset it,
+/// so this alone does NOT protect against "connection stays open but no
+/// prices flow" — that's what `DEFAULT_PRICE_STALL_TIMEOUT` is for.
 const SSE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Payload-level liveness: reconnect if no parseable `PriceUpdate`
+/// arrives within this window, even if heartbeats or garbage frames
+/// keep resetting the frame-level timer. Anchors "connected" to actual
+/// market-data flow instead of wire-level activity.
+const DEFAULT_PRICE_STALL_TIMEOUT: Duration = Duration::from_secs(60);
 const INITIAL_RECONNECT_BACKOFF_SECS: u64 = 5;
 const MAX_RECONNECT_BACKOFF_SECS: u64 = 60;
 const MAX_RECEIVE_LAG_MS: i64 = 10_000;
@@ -107,6 +120,7 @@ pub struct PythClient {
     event_tx: mpsc::Sender<OracleEvent>,
     assets: Vec<Asset>,
     hermes_url: String,
+    price_stall_timeout: Duration,
 }
 
 impl PythClient {
@@ -115,6 +129,7 @@ impl PythClient {
             event_tx,
             assets,
             hermes_url: HERMES_URL.to_string(),
+            price_stall_timeout: DEFAULT_PRICE_STALL_TIMEOUT,
         }
     }
 
@@ -123,7 +138,16 @@ impl PythClient {
             event_tx,
             assets,
             hermes_url: url.to_string(),
+            price_stall_timeout: DEFAULT_PRICE_STALL_TIMEOUT,
         }
+    }
+
+    /// Override the payload-level liveness deadline. Test-only seam; prod
+    /// should use `DEFAULT_PRICE_STALL_TIMEOUT`.
+    #[cfg(test)]
+    pub(crate) fn with_price_stall_timeout(mut self, timeout: Duration) -> Self {
+        self.price_stall_timeout = timeout;
+        self
     }
 
     pub async fn run(&mut self) -> anyhow::Result<()> {
@@ -171,7 +195,19 @@ impl PythClient {
         let url = format!("{}/v2/updates/price/latest?{}", self.hermes_url, query);
         debug!("Fetching latest prices from: {}", url);
 
-        let response = reqwest::get(&url).await?;
+        // Same UA + explicit non-success handling as the SSE path, so both
+        // code paths get the same triage shape. `reqwest::get` uses a
+        // default, unconfigured client, which is what we want to avoid.
+        let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+        let response = client.get(&url).send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            error!(
+                status = %status,
+                "Pyth Hermes returned non-success status for /latest request"
+            );
+            anyhow::bail!("Pyth Hermes rejected /latest request: status={}", status);
+        }
         let data: HermesPriceResponse = response.json().await?;
 
         Ok(data
@@ -192,14 +228,41 @@ impl PythClient {
         let url = format!("{}/v2/updates/price/stream?{}", self.hermes_url, query);
         info!("Connecting to Pyth Hermes SSE stream: {}", url);
 
-        let client = eventsource_client::ClientBuilder::for_url(&url)?.build();
+        let client = eventsource_client::ClientBuilder::for_url(&url)?
+            .header("User-Agent", USER_AGENT)?
+            .build();
         let mut stream = client.stream();
         let mut freshness_state: HashMap<String, AssetFreshnessState> = HashMap::new();
-
-        let _ = self.event_tx.send(OracleEvent::Connected).await;
-        info!("Connected to Pyth Hermes");
+        // Two distinct states. The 2026-04-24 outage shape was precisely
+        // "HTTP OK, then zero payloads" — conflating the two would make
+        // "Connected" log lines lie about whether market data is flowing.
+        //   handshake_ok   => SSE::Connected fired (server returned 2xx)
+        //   streaming_live => first PriceUpdate parsed and emitted
+        // OracleEvent::Connected only fires on streaming_live.
+        let mut handshake_ok = false;
+        let mut streaming_live = false;
+        // Payload-level watchdog. Armed on SSE::Connected and reset on
+        // every emitted PriceUpdate. If heartbeats or malformed events
+        // keep the frame timer alive but no real prices ever parse out,
+        // this deadline fires and forces a reconnect.
+        let mut price_deadline: Option<Instant> = None;
 
         loop {
+            if let Some(deadline) = price_deadline {
+                if Instant::now() >= deadline {
+                    warn!(
+                        stall_timeout_secs = self.price_stall_timeout.as_secs(),
+                        handshake_ok,
+                        streaming_live,
+                        "No PriceUpdate received within stall timeout; forcing reconnect"
+                    );
+                    return Err(anyhow::anyhow!(
+                        "Pyth Hermes PriceUpdate stall for {}s",
+                        self.price_stall_timeout.as_secs()
+                    ));
+                }
+            }
+
             let event = match tokio::time::timeout(SSE_IDLE_TIMEOUT, stream.next()).await {
                 Ok(Some(event)) => event,
                 Ok(None) => {
@@ -209,6 +272,8 @@ impl PythClient {
                 Err(_) => {
                     warn!(
                         idle_timeout_secs = SSE_IDLE_TIMEOUT.as_secs(),
+                        handshake_ok,
+                        streaming_live,
                         "No SSE events received from Hermes; forcing reconnect"
                     );
                     return Err(anyhow::anyhow!(
@@ -219,11 +284,38 @@ impl PythClient {
             };
 
             match event {
+                Ok(SSE::Connected(_)) => {
+                    // HTTP 2xx received. Do NOT announce "Connected to Pyth
+                    // Hermes" here — in the failure mode we care about,
+                    // the server 200s and then sends nothing.
+                    if !handshake_ok {
+                        debug!("Pyth Hermes HTTP handshake accepted; awaiting first payload");
+                        handshake_ok = true;
+                        price_deadline = Some(Instant::now() + self.price_stall_timeout);
+                    }
+                }
                 Ok(SSE::Event(ev)) if ev.event_type == "message" => {
                     match serde_json::from_str::<StreamUpdate>(&ev.data) {
                         Ok(update) => {
                             for parsed in update.parsed {
                                 if let Some(price_update) = self.parse_price_update(parsed) {
+                                    if !streaming_live {
+                                        // First real payload of this connection.
+                                        // "Connected" now means market data is
+                                        // actually flowing, not just that the
+                                        // HTTP handshake succeeded.
+                                        info!("Connected to Pyth Hermes");
+                                        let _ =
+                                            self.event_tx.send(OracleEvent::Connected).await;
+                                        streaming_live = true;
+                                    }
+                                    // Reset the payload-level watchdog on
+                                    // every successful PriceUpdate, so
+                                    // heartbeats + garbage frames cannot
+                                    // hold the connection open forever.
+                                    price_deadline =
+                                        Some(Instant::now() + self.price_stall_timeout);
+
                                     let receive_time = unix_now_secs();
                                     let now = Instant::now();
                                     let state = freshness_state
@@ -272,10 +364,21 @@ impl PythClient {
                         }
                     }
                 }
-                Ok(SSE::Connected(_)) => {
-                    debug!("Hermes SSE connected");
-                }
                 Ok(SSE::Comment(_)) => {}
+                Err(eventsource_client::Error::UnexpectedResponse(resp, _)) => {
+                    // Explicit non-2xx from Hermes. Log status as a
+                    // structured field so 403/429/5xx is grep-able and
+                    // distinct from the idle-timeout path.
+                    let status = resp.status();
+                    error!(
+                        status = %status,
+                        "Pyth Hermes returned non-success status for SSE request"
+                    );
+                    return Err(anyhow::anyhow!(
+                        "Pyth Hermes rejected SSE request: status={}",
+                        status
+                    ));
+                }
                 Err(e) => {
                     return Err(anyhow::anyhow!("SSE stream error: {}", e));
                 }
@@ -432,5 +535,307 @@ mod tests {
         assert_eq!(update.symbol, "SOL");
         assert!((update.price - 123.45).abs() < f64::EPSILON);
         assert!((update.confidence - 0.67).abs() < f64::EPSILON);
+    }
+
+    /// Pin the User-Agent we send to Hermes. Originally added after a
+    /// 2026-04-24 incident where the oracle stalled for ~90 minutes and
+    /// identifying our traffic in upstream logs would have shortened
+    /// triage. An explicit UA also insulates us from any bot-detection
+    /// heuristic that keys on the absence of one.
+    #[tokio::test]
+    async fn connect_sends_joyride_user_agent_header() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start_async().await;
+        let ua_mock = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/v2/updates/price/stream")
+                    .header_exists("user-agent")
+                    .matches(|req| {
+                        req.headers
+                            .as_ref()
+                            .and_then(|hs| {
+                                hs.iter()
+                                    .find(|(k, _)| k.eq_ignore_ascii_case("user-agent"))
+                                    .map(|(_, v)| v.contains("joyride-oracle"))
+                            })
+                            .unwrap_or(false)
+                    });
+                then.status(200)
+                    .header("content-type", "text/event-stream")
+                    .body("");
+            })
+            .await;
+
+        let (tx, _rx) = mpsc::channel(16);
+        let mut client = PythClient::with_url(tx, vec![Asset::Btc], &server.base_url());
+
+        // run() loops on reconnect forever; cap it so the test can observe
+        // at least one request reaching the mock and then return.
+        let _ = tokio::time::timeout(Duration::from_secs(2), client.run()).await;
+
+        ua_mock.assert_async().await;
+    }
+
+    fn sse_price_event_body(feed_id: &str) -> String {
+        // Minimal parseable SSE "message" event with one parsed price.
+        // expo=-8 → price field is raw × 10^-8. 10_000_000_000 ⇒ $100.
+        let payload = serde_json::json!({
+            "parsed": [{
+                "id": feed_id,
+                "price": {"price": "10000000000", "conf": "1000000", "expo": -8, "publish_time": 1000},
+                "ema_price": {"price": "10000000000", "conf": "1000000", "expo": -8, "publish_time": 1000}
+            }]
+        });
+        format!("event: message\ndata: {}\n\n", payload)
+    }
+
+    /// Failure-mode pin. The 2026-04-24 outage shape was "HTTP 200, then
+    /// zero SSE payloads for 30s." The oracle must NOT emit
+    /// OracleEvent::Connected in that case — that signal is now reserved
+    /// for "we actually received market data."
+    #[tokio::test]
+    async fn connected_event_does_not_fire_on_silent_200_from_hermes() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v2/updates/price/stream");
+                then.status(200)
+                    .header("content-type", "text/event-stream")
+                    .body("");
+            })
+            .await;
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut client = PythClient::with_url(tx, vec![Asset::Btc], &server.base_url());
+
+        let _ = tokio::time::timeout(Duration::from_millis(500), client.run()).await;
+
+        let mut saw_connected = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev, OracleEvent::Connected) {
+                saw_connected = true;
+            }
+        }
+        assert!(
+            !saw_connected,
+            "OracleEvent::Connected must not fire on HTTP-OK + empty body \
+             (handshake without any payload)"
+        );
+    }
+
+    /// Happy-path pin. Once a real price event parses out of the stream,
+    /// OracleEvent::Connected should fire, and it should come at or
+    /// before the first Price event so downstream consumers can treat
+    /// "Connected" as a reliable precondition.
+    #[tokio::test]
+    async fn connected_event_fires_on_first_parseable_price_payload() {
+        use httpmock::prelude::*;
+
+        let feed_id = Asset::Btc.feed_id();
+        let body = sse_price_event_body(feed_id);
+
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v2/updates/price/stream");
+                then.status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(&body);
+            })
+            .await;
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let mut client = PythClient::with_url(tx, vec![Asset::Btc], &server.base_url());
+
+        let _ = tokio::time::timeout(Duration::from_secs(1), client.run()).await;
+
+        let mut events = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            events.push(ev);
+        }
+        let connected_idx = events
+            .iter()
+            .position(|e| matches!(e, OracleEvent::Connected));
+        let first_price_idx = events
+            .iter()
+            .position(|e| matches!(e, OracleEvent::Price(_)));
+
+        let connected_idx = connected_idx
+            .expect("OracleEvent::Connected must fire after the first parseable SSE payload");
+        let first_price_idx =
+            first_price_idx.expect("OracleEvent::Price must fire for the payload");
+        assert!(
+            connected_idx <= first_price_idx,
+            "Connected ({connected_idx}) must precede or coincide with first Price ({first_price_idx})"
+        );
+    }
+
+    /// Mirror of the SSE UA pin for the REST `/latest` path. Same crime,
+    /// same fix — keep both paths in sync.
+    #[tokio::test]
+    async fn fetch_latest_sends_joyride_user_agent_header() {
+        use httpmock::prelude::*;
+
+        let feed_id = Asset::Btc.feed_id();
+        let body = serde_json::json!({
+            "parsed": [{
+                "id": feed_id,
+                "price": {"price": "10000000000", "conf": "1000000", "expo": -8, "publish_time": 1000},
+                "ema_price": {"price": "10000000000", "conf": "1000000", "expo": -8, "publish_time": 1000}
+            }]
+        });
+
+        let server = MockServer::start_async().await;
+        let ua_mock = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/v2/updates/price/latest")
+                    .matches(|req| {
+                        req.headers
+                            .as_ref()
+                            .and_then(|hs| {
+                                hs.iter()
+                                    .find(|(k, _)| k.eq_ignore_ascii_case("user-agent"))
+                                    .map(|(_, v)| v.contains("joyride-oracle"))
+                            })
+                            .unwrap_or(false)
+                    });
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(body.to_string());
+            })
+            .await;
+
+        let (tx, _rx) = mpsc::channel(16);
+        let client = PythClient::with_url(tx, vec![Asset::Btc], &server.base_url());
+
+        let updates = client
+            .fetch_latest()
+            .await
+            .expect("fetch_latest should succeed against mock");
+        assert_eq!(updates.len(), 1);
+        ua_mock.assert_async().await;
+    }
+
+    /// On a non-2xx from `/latest`, surface an error whose message includes
+    /// the status code, so triage can grep for the exact status.
+    #[tokio::test]
+    async fn fetch_latest_errors_on_non_success_status() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v2/updates/price/latest");
+                then.status(429).body("Too Many Requests");
+            })
+            .await;
+
+        let (tx, _rx) = mpsc::channel(16);
+        let client = PythClient::with_url(tx, vec![Asset::Btc], &server.base_url());
+
+        let err = client
+            .fetch_latest()
+            .await
+            .expect_err("fetch_latest must error on non-2xx");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("429"),
+            "error message must include the status code: {msg}"
+        );
+    }
+
+    /// Heartbeats-forever fake SSE server. httpmock can't hold a streaming
+    /// body open, so we do it by hand: accept one connection, write
+    /// HTTP/200 headers, drip SSE `: heartbeat` comments every 10 ms until
+    /// the client disconnects. Used by the payload-level stall test below
+    /// to simulate "connection stays open but no prices flow."
+    async fn spawn_heartbeat_only_sse_server() -> (String, tokio::task::JoinHandle<()>) {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let base_url = format!("http://{addr}");
+        let handle = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                tokio::spawn(async move {
+                    // Consume the request line + headers (until \r\n\r\n)
+                    // so the client side of the request is actually read.
+                    let mut buf = [0u8; 1024];
+                    use tokio::io::AsyncReadExt;
+                    let _ = socket.read(&mut buf).await;
+
+                    let headers = b"HTTP/1.1 200 OK\r\n\
+                                    content-type: text/event-stream\r\n\
+                                    cache-control: no-cache\r\n\
+                                    connection: keep-alive\r\n\
+                                    \r\n";
+                    if socket.write_all(headers).await.is_err() {
+                        return;
+                    }
+                    loop {
+                        if socket.write_all(b": heartbeat\n\n").await.is_err() {
+                            return;
+                        }
+                        let _ = socket.flush().await;
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                });
+            }
+        });
+        (base_url, handle)
+    }
+
+    /// Pins the gap the frame-level idle timer doesn't cover: heartbeats
+    /// reset SSE_IDLE_TIMEOUT, so without a payload-level deadline the
+    /// oracle could stay "connected" forever while the order book is
+    /// empty.
+    #[tokio::test]
+    async fn stall_watchdog_forces_reconnect_when_only_heartbeats_arrive() {
+        let (url, server_handle) = spawn_heartbeat_only_sse_server().await;
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let mut client = PythClient::with_url(tx, vec![Asset::Btc], &url)
+            .with_price_stall_timeout(Duration::from_millis(200));
+
+        // 1.5 s covers ~50 ms handshake + 200 ms stall deadline + room
+        // for the reconnect path to fire OracleEvent::Error before the
+        // outer timeout kicks in. The 5 s reconnect backoff is capped
+        // off by our timeout first.
+        let _ = tokio::time::timeout(Duration::from_millis(1500), client.run()).await;
+        server_handle.abort();
+
+        let mut saw_error_with_stall = false;
+        let mut saw_connected = false;
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                OracleEvent::Error { message } if message.contains("PriceUpdate stall") => {
+                    saw_error_with_stall = true;
+                }
+                OracleEvent::Connected => {
+                    saw_connected = true;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            saw_error_with_stall,
+            "payload-level stall watchdog must fire when heartbeats \
+             keep the frame-level timer reset but no PriceUpdate arrives"
+        );
+        assert!(
+            !saw_connected,
+            "OracleEvent::Connected must not fire when only heartbeats arrive"
+        );
     }
 }


### PR DESCRIPTION
A production stall left publish_time frozen for ~90 minutes despite the 30s SSE idle timeout firing every reconnect cycle. The handshake kept returning 200 and the SSE stream kept producing comment frames, so the frame-level idle timer reset on every heartbeat and never tripped. Three gaps closed:

1. Explicit User-Agent (joyride-oracle/1.0) on both the SSE stream and the REST /latest path. eventsource-client 0.13 sets only Accept and Cache-Control; reqwest::get uses an unconfigured client. An explicit UA makes our traffic identifiable to Hermes/Cloudflare and insulates us from bot-detection heuristics that key on the absence of one.

2. Split handshake-OK from streaming-live. OracleEvent::Connected and the "Connected to Pyth Hermes" log previously fired immediately after client.stream() returned, before any wire traffic — so during the incident the logs claimed we were connected while receiving zero payloads. Both now fire on the first parseable PriceUpdate. handshake_ok / streaming_live are also added as structured fields to the 30s idle warn so future stalls classify as "never-handshook," "handshook-but-silent," or "was-streaming-then-stopped" in seconds.

3. Payload-level stall watchdog (DEFAULT_PRICE_STALL_TIMEOUT, 60s). Armed on SSE::Connected and reset only when a PriceUpdate is successfully parsed and forwarded. Heartbeats and malformed frames do NOT reset it. On fire, the connection is torn down and the normal reconnect-with-backoff path runs.

Also: explicit non-2xx handling on both paths. eventsource-client surfaces 403/429/5xx as Error::UnexpectedResponse; the new arm logs the status as a structured field and bails. fetch_latest now checks Response::status() before .json() so a 5xx HTML body doesn't surface as an opaque parse error.

Adds httpmock as a dev-dep and 6 tests pinning each behavior, including a hand-rolled fake SSE server for the heartbeats-only stall case (httpmock can't hold streaming bodies open). Production tokio feature surface unchanged; new features are scoped to dev-dependencies.

No public API change. OracleEvent::Connected semantics narrow from "handshake succeeded" to "market data is flowing" — downstream consumers that were already treating it as the latter (the only useful reading) keep working; any consumer relying on the old timing now gets a more accurate signal.